### PR TITLE
Add coins to teams and user add/remove route

### DIFF
--- a/src/pwncore/config.py
+++ b/src/pwncore/config.py
@@ -51,6 +51,7 @@ class Config:
     jwt_secret: str
     jwt_valid_duration: int
     hint_penalty: int
+    max_members_per_team: int
 
 
 config = Config(
@@ -65,4 +66,5 @@ config = Config(
     jwt_valid_duration=12,  # In hours
     msg_codes=msg_codes,
     hint_penalty=10,
+    max_members_per_team=3,
 )

--- a/src/pwncore/config.py
+++ b/src/pwncore/config.py
@@ -56,9 +56,9 @@ class Config:
 config = Config(
     development=True,
     db_url="sqlite://:memory:",
-    # docker_url=None,  # None for default system docker
+    docker_url=None,  # None for default system docker
     # Or set it to an arbitrary URL for testing without Docker
-    docker_url="http://google.com",
+    # docker_url="http://google.com",
     flag="C0D",
     max_containers_per_team=3,
     jwt_secret="mysecret",

--- a/src/pwncore/config.py
+++ b/src/pwncore/config.py
@@ -36,7 +36,7 @@ msg_codes = {
     "user_removed": 19,
     "user_already_in_team": 20,
     "user_not_in_team": 21,
-    "insufficient_coins": 22
+    "insufficient_coins": 22,
 }
 
 
@@ -64,5 +64,5 @@ config = Config(
     jwt_secret="mysecret",
     jwt_valid_duration=12,  # In hours
     msg_codes=msg_codes,
-    hint_penalty=10
+    hint_penalty=10,
 )

--- a/src/pwncore/config.py
+++ b/src/pwncore/config.py
@@ -57,9 +57,9 @@ class Config:
 config = Config(
     development=True,
     db_url="sqlite://:memory:",
-    docker_url=None,  # None for default system docker
+    # docker_url=None,  # None for default system docker
     # Or set it to an arbitrary URL for testing without Docker
-    # docker_url="http://google.com",
+    docker_url="http://google.com",
     flag="C0D",
     max_containers_per_team=3,
     jwt_secret="mysecret",

--- a/src/pwncore/config.py
+++ b/src/pwncore/config.py
@@ -32,6 +32,7 @@ msg_codes = {
     "wrong_password": 14,
     "login_success": 15,
     "team_exists": 17,
+    "insufficient_coins": 18
 }
 
 
@@ -45,15 +46,19 @@ class Config:
     max_containers_per_team: int
     jwt_secret: str
     jwt_valid_duration: int
+    hint_penalty: int
 
 
 config = Config(
     development=True,
     db_url="sqlite://:memory:",
-    docker_url=None,  # None for default system docker
+    # docker_url=None,  # None for default system docker
+    # Or set it to an arbitrary URL for testing without Docker
+    docker_url="http://google.com",
     flag="C0D",
     max_containers_per_team=3,
     jwt_secret="mysecret",
     jwt_valid_duration=12,  # In hours
     msg_codes=msg_codes,
+    hint_penalty=10
 )

--- a/src/pwncore/config.py
+++ b/src/pwncore/config.py
@@ -32,6 +32,7 @@ msg_codes = {
     "wrong_password": 14,
     "login_success": 15,
     "team_exists": 17,
+    "user_created": 18,
     "insufficient_coins": 18
 }
 

--- a/src/pwncore/config.py
+++ b/src/pwncore/config.py
@@ -32,8 +32,11 @@ msg_codes = {
     "wrong_password": 14,
     "login_success": 15,
     "team_exists": 17,
-    "user_created": 18,
-    "insufficient_coins": 18
+    "user_added": 18,
+    "user_removed": 19,
+    "user_already_in_team": 20,
+    "user_not_in_team": 21,
+    "insufficient_coins": 22
 }
 
 

--- a/src/pwncore/models/__init__.py
+++ b/src/pwncore/models/__init__.py
@@ -11,6 +11,7 @@ from pwncore.models.ctf import (
     ViewedHint,
     Problem_Pydantic,
     Hint_Pydantic,
+    PreEventSolvedProblem,
 )
 from pwncore.models.user import User, Team, Team_Pydantic, User_Pydantic
 
@@ -24,6 +25,7 @@ __all__ = (
     "Container",
     "Ports",
     "User",
+    "PreEventSolvedProblem",
     "User_Pydantic",
     "Team",
     "Team_Pydantic",

--- a/src/pwncore/models/__init__.py
+++ b/src/pwncore/models/__init__.py
@@ -9,15 +9,18 @@ from pwncore.models.ctf import (
     SolvedProblem,
     Hint,
     ViewedHint,
-    Problem_Pydantic,
     Hint_Pydantic,
-    PreEventSolvedProblem,
+    BaseProblem_Pydantic,
 )
 from pwncore.models.user import User, Team, Team_Pydantic, User_Pydantic
+from pwncore.models.pre_event import (
+    PreEventProblem,
+    PreEventSolvedProblem,
+)
 
 __all__ = (
     "Problem",
-    "Problem_Pydantic",
+    "BaseProblem_Pydantic",
     "Hint",
     "Hint_Pydantic",
     "SolvedProblem",
@@ -26,6 +29,7 @@ __all__ = (
     "Ports",
     "User",
     "PreEventSolvedProblem",
+    "PreEventProblem",
     "User_Pydantic",
     "Team",
     "Team_Pydantic",

--- a/src/pwncore/models/ctf.py
+++ b/src/pwncore/models/ctf.py
@@ -22,6 +22,8 @@ class Problem(Model):
     points = fields.IntField()
     author = fields.TextField()
 
+    coins = fields.IntField(default=0)
+
     image_name = fields.TextField()
     image_config: fields.Field[dict[str, list]] = fields.JSONField()  # type: ignore[assignment]
 

--- a/src/pwncore/models/ctf.py
+++ b/src/pwncore/models/ctf.py
@@ -46,7 +46,9 @@ class Hint(Model):
 
 
 class SolvedProblem(Model):
-    team: fields.ForeignKeyRelation[Team] = fields.ForeignKeyField("models.Team")
+    team: fields.ForeignKeyRelation[Team] = fields.ForeignKeyField(
+        "models.Team", related_name="solved_problem"
+    )
     problem: fields.ForeignKeyRelation[Problem] = fields.ForeignKeyField(
         "models.Problem"
     )

--- a/src/pwncore/models/ctf.py
+++ b/src/pwncore/models/ctf.py
@@ -51,8 +51,7 @@ class Hint(Model):
 
 
 class SolvedProblem(Model):
-    team: fields.ForeignKeyRelation[Team] = fields.ForeignKeyField(
-        "models.Team")
+    team: fields.ForeignKeyRelation[Team] = fields.ForeignKeyField("models.Team")
     problem: fields.ForeignKeyRelation[Problem] = fields.ForeignKeyField(
         "models.Problem"
     )
@@ -63,8 +62,7 @@ class SolvedProblem(Model):
 
 
 class ViewedHint(Model):
-    team: fields.ForeignKeyRelation[Team] = fields.ForeignKeyField(
-        "models.Team")
+    team: fields.ForeignKeyRelation[Team] = fields.ForeignKeyField("models.Team")
     hint: fields.ForeignKeyRelation[Hint] = fields.ForeignKeyField(
         "models.Hint",
     )

--- a/src/pwncore/models/ctf.py
+++ b/src/pwncore/models/ctf.py
@@ -11,31 +11,26 @@ __all__ = (
     "Hint",
     "SolvedProblem",
     "ViewedHint",
-    "PreEventSolvedProblem",
-    "Problem_Pydantic",
+    "BaseProblem_Pydantic",
     "Hint_Pydantic",
 )
 
 
-class Problem(Model):
+class BaseProblem(Model):
     name = fields.TextField()
     description = fields.TextField()
+    # both tables inherit points, for pre-event points means coins
     points = fields.IntField()
     author = fields.TextField()
 
-    coins = fields.IntField(default=0)
 
-    flag = fields.TextField(null=True)  # Static flag CTFs
-
-    image_name = fields.TextField(null=True)
+class Problem(BaseProblem):
+    image_name = fields.TextField()
     image_config: fields.Field[dict[str, list]] = fields.JSONField(
         null=True
     )  # type: ignore[assignment]
 
     hints: fields.ReverseRelation[Hint]
-
-    class PydanticMeta:
-        exclude = ["image_name", "image_config", "flag"]
 
 
 class Hint(Model):
@@ -71,16 +66,5 @@ class ViewedHint(Model):
         unique_together = (("team", "hint"),)
 
 
-class PreEventSolvedProblem(Model):
-    tag = fields.CharField(128)
-    problem: fields.ForeignKeyRelation[Problem] = fields.ForeignKeyField(
-        "models.Problem"
-    )
-    solved_at = fields.DatetimeField(auto_now_add=True)
-
-    class Meta:
-        unique_together = (("tag", "problem"),)
-
-
-Problem_Pydantic = pydantic_model_creator(Problem)
+BaseProblem_Pydantic = pydantic_model_creator(BaseProblem)
 Hint_Pydantic = pydantic_model_creator(Hint)

--- a/src/pwncore/models/ctf.py
+++ b/src/pwncore/models/ctf.py
@@ -11,6 +11,7 @@ __all__ = (
     "Hint",
     "SolvedProblem",
     "ViewedHint",
+    "PreEventSolvedProblem",
     "Problem_Pydantic",
     "Hint_Pydantic",
 )
@@ -24,13 +25,17 @@ class Problem(Model):
 
     coins = fields.IntField(default=0)
 
+    flag = fields.TextField(null=True)  # Static flag CTFs
+
     image_name = fields.TextField()
-    image_config: fields.Field[dict[str, list]] = fields.JSONField()  # type: ignore[assignment]
+    image_config: fields.Field[dict[str, list]] = fields.JSONField(
+        null=True
+    )  # type: ignore[assignment]
 
     hints: fields.ReverseRelation[Hint]
 
     class PydanticMeta:
-        exclude = ["image_name", "image_config"]
+        exclude = ["image_name", "image_config", "flag"]
 
 
 class Hint(Model):
@@ -64,6 +69,17 @@ class ViewedHint(Model):
 
     class Meta:
         unique_together = (("team", "hint"),)
+
+
+class PreEventSolvedProblem(Model):
+    tag = fields.CharField(128)
+    problem: fields.ForeignKeyRelation[Problem] = fields.ForeignKeyField(
+        "models.Problem"
+    )
+    solved_at = fields.DatetimeField(auto_now_add=True)
+
+    class Meta:
+        unique_together = (("tag", "problem"),)
 
 
 Problem_Pydantic = pydantic_model_creator(Problem)

--- a/src/pwncore/models/ctf.py
+++ b/src/pwncore/models/ctf.py
@@ -27,7 +27,7 @@ class Problem(Model):
 
     flag = fields.TextField(null=True)  # Static flag CTFs
 
-    image_name = fields.TextField()
+    image_name = fields.TextField(null=True)
     image_config: fields.Field[dict[str, list]] = fields.JSONField(
         null=True
     )  # type: ignore[assignment]
@@ -51,7 +51,8 @@ class Hint(Model):
 
 
 class SolvedProblem(Model):
-    team: fields.ForeignKeyRelation[Team] = fields.ForeignKeyField("models.Team")
+    team: fields.ForeignKeyRelation[Team] = fields.ForeignKeyField(
+        "models.Team")
     problem: fields.ForeignKeyRelation[Problem] = fields.ForeignKeyField(
         "models.Problem"
     )
@@ -62,7 +63,8 @@ class SolvedProblem(Model):
 
 
 class ViewedHint(Model):
-    team: fields.ForeignKeyRelation[Team] = fields.ForeignKeyField("models.Team")
+    team: fields.ForeignKeyRelation[Team] = fields.ForeignKeyField(
+        "models.Team")
     hint: fields.ForeignKeyRelation[Hint] = fields.ForeignKeyField(
         "models.Hint",
     )

--- a/src/pwncore/models/pre_event.py
+++ b/src/pwncore/models/pre_event.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from tortoise.models import Model
+from tortoise import fields
+
+from pwncore.models.ctf import BaseProblem
+
+__all__ = (
+    "PreEventSolvedProblem",
+    "PreEventProblem",
+)
+
+
+class PreEventProblem(BaseProblem):
+    flag = fields.TextField()
+    url = fields.TextField()  # Link to CTF file/repo/website
+
+
+class PreEventSolvedProblem(Model):
+    tag = fields.CharField(128)
+    problem: fields.ForeignKeyRelation[PreEventProblem] = fields.ForeignKeyField(
+        "models.PreEventProblem"
+    )
+    solved_at = fields.DatetimeField(auto_now_add=True)
+
+    class Meta:
+        unique_together = (("tag", "problem"),)

--- a/src/pwncore/models/user.py
+++ b/src/pwncore/models/user.py
@@ -7,6 +7,7 @@ from tortoise.expressions import Q
 from tortoise.contrib.pydantic import pydantic_model_creator
 
 from pwncore.models.container import Container
+from pwncore.config import config
 
 __all__ = (
     "User",
@@ -34,8 +35,11 @@ class User(Model):
         # Reason why we dont use pre_save: overhead, ugly
         if self.team is not None and hasattr(self.team, "members"):
             count = await self.team.members.filter(~Q(id=self.pk)).count()
-            if count >= 3:
-                raise IntegrityError("3 or more users already exist for the team")
+            if count >= config.max_members_per_team:
+                raise IntegrityError(
+                    f"{config.max_members_per_team}"
+                    " or more users already exist for the team"
+                )
         return await super().save(*args, **kwargs)
 
 

--- a/src/pwncore/models/user.py
+++ b/src/pwncore/models/user.py
@@ -35,8 +35,7 @@ class User(Model):
         if self.team is not None and hasattr(self.team, "members"):
             count = await self.team.members.filter(~Q(id=self.pk)).count()
             if count >= 3:
-                raise IntegrityError(
-                    "3 or more users already exist for the team")
+                raise IntegrityError("3 or more users already exist for the team")
         return await super().save(*args, **kwargs)
 
 

--- a/src/pwncore/models/user.py
+++ b/src/pwncore/models/user.py
@@ -35,7 +35,8 @@ class User(Model):
         if self.team is not None and hasattr(self.team, "members"):
             count = await self.team.members.filter(~Q(id=self.pk)).count()
             if count >= 3:
-                raise IntegrityError("3 or more users already exist for the team")
+                raise IntegrityError(
+                    "3 or more users already exist for the team")
         return await super().save(*args, **kwargs)
 
 
@@ -45,6 +46,7 @@ class Team(Model):
     )  # team.id raises Team does not have id, so explicitly adding it
     name = fields.CharField(255, unique=True)
     secret_hash = fields.TextField()
+    coins = fields.IntField(default=0)
 
     members: fields.ReverseRelation[User]
     containers: fields.ReverseRelation[Container]

--- a/src/pwncore/routes/__init__.py
+++ b/src/pwncore/routes/__init__.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from pwncore.routes import ctf, team, auth, admin
+from pwncore.routes import ctf, team, auth, admin, leaderboard
 from pwncore.config import config
 
 # Main router (all routes go under /api)
@@ -10,5 +10,6 @@ router = APIRouter(prefix="/api")
 router.include_router(auth.router)
 router.include_router(ctf.router)
 router.include_router(team.router)
+router.include_router(leaderboard.router)
 if config.development:
     router.include_router(admin.router)

--- a/src/pwncore/routes/admin.py
+++ b/src/pwncore/routes/admin.py
@@ -11,6 +11,7 @@ from pwncore.models import (
     PreEventProblem,
 )
 from pwncore.config import config
+from pwncore.models.ctf import SolvedProblem
 
 metadata = {
     "name": "admin",
@@ -146,3 +147,6 @@ async def init_db():
     await Hint.create(order=2, problem_id=1, text="This is the third hint")
     await Hint.create(order=0, problem_id=2, text="This is the first hint")
     await Hint.create(order=1, problem_id=2, text="This is the second hint")
+    await SolvedProblem.create(team_id=2, problem_id=1)
+    await SolvedProblem.create(team_id=2, problem_id=2)
+    await SolvedProblem.create(team_id=1, problem_id=2)

--- a/src/pwncore/routes/admin.py
+++ b/src/pwncore/routes/admin.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter
+from passlib.hash import bcrypt
 
 from pwncore.models import Team, Problem, Hint, User
 
@@ -28,8 +29,8 @@ async def init_db():
         image_name="key:latest",
         image_config={"PortBindings": {"22/tcp": [{}]}},
     )
-    await Team.create(name="CID Squad", secret_hash="veryverysecret")
-    await Team.create(name="Triple A battery", secret_hash="chotiwali")
+    await Team.create(name="CID Squad", secret_hash=bcrypt.hash("veryverysecret"))
+    await Team.create(name="Triple A battery", secret_hash=bcrypt.hash("chotiwali"), coins=20)
     await User.create(
         tag="23BRS1000",
         name="abc",

--- a/src/pwncore/routes/admin.py
+++ b/src/pwncore/routes/admin.py
@@ -22,14 +22,16 @@ async def calculate_team_coins():  # Inefficient, anyways will be used only once
     logging.info("Calculating team points form pre-event CTFs:")
     team_ids = await Team.filter().values_list("id", flat=True)
     for team_id in team_ids:
-        member_tags = await User.filter(team_id=team_id).values_list('tag', flat=True)
+        member_tags = await User.filter(team_id=team_id).values_list("tag", flat=True)
 
         if not member_tags:
             return 0
 
-        problems_solved = set(await PreEventSolvedProblem.filter(
-            tag__in=member_tags
-        ).values_list('problem_id', flat=True))
+        problems_solved = set(
+            await PreEventSolvedProblem.filter(tag__in=member_tags).values_list(
+                "problem_id", flat=True
+            )
+        )
 
         team = await Team.get(id=team_id)
         for ctf_id in problems_solved:
@@ -77,14 +79,8 @@ async def init_db():
     await Team.create(
         name="Triple A battery", secret_hash=bcrypt.hash("chotiwali"), coins=20
     )
-    await PreEventSolvedProblem.create(
-        tag="23BCE1000",
-        problem_id="1"
-    )
-    await PreEventSolvedProblem.create(
-        tag="23BRS1000",
-        problem_id="2"
-    )
+    await PreEventSolvedProblem.create(tag="23BCE1000", problem_id="1")
+    await PreEventSolvedProblem.create(tag="23BRS1000", problem_id="2")
     # await PreEventSolvedProblem.create(
     #     tag="23BAI1000",
     #     problem_id="2"

--- a/src/pwncore/routes/admin.py
+++ b/src/pwncore/routes/admin.py
@@ -22,12 +22,28 @@ async def init_db():
         image_config={"PortBindings": {"22/tcp": [{}]}},
     )
     await Problem.create(
+        name="Static_test",
+        description="Chod de tujhe se na ho paye",
+        author="Meetesh Saini",
+        points=300,
+        coins=20,
+        flag="asd",
+    )
+    await Problem.create(
         name="In-Plain-Sight",
         description="A curious image with hidden secrets?",
         author="KreativeThinker",
         points=300,
         image_name="key:latest",
         image_config={"PortBindings": {"22/tcp": [{}]}},
+    )
+    await Problem.create(
+        name="GitGood",
+        description="How to master the art of solving CTFs? Git good nub.",
+        author="Aadivishnu and Shoubhit",
+        points=300,
+        image_name="test:latest",
+        image_config={"PortBindings": {"22/tcp": [{}], "5000/tcp": [{}]}},
     )
     await Team.create(name="CID Squad", secret_hash=bcrypt.hash("veryverysecret"))
     await Team.create(

--- a/src/pwncore/routes/admin.py
+++ b/src/pwncore/routes/admin.py
@@ -2,7 +2,14 @@ import logging
 from fastapi import APIRouter
 from passlib.hash import bcrypt
 
-from pwncore.models import Team, Problem, Hint, User, PreEventSolvedProblem
+from pwncore.models import (
+    Team,
+    Problem,
+    Hint,
+    User,
+    PreEventSolvedProblem,
+    PreEventProblem,
+)
 from pwncore.config import config
 
 metadata = {
@@ -35,7 +42,7 @@ async def calculate_team_coins():  # Inefficient, anyways will be used only once
 
         team = await Team.get(id=team_id)
         for ctf_id in problems_solved:
-            team.coins += (await Problem.get(id=ctf_id)).coins
+            team.coins += (await PreEventProblem.get(id=ctf_id)).points
         logging.info(f"{team.id}) {team.name}: {team.coins}")
         await team.save()
 
@@ -47,17 +54,24 @@ async def init_db():
         description="Chod de tujhe se na ho paye",
         author="Meetesh Saini",
         points=300,
-        coins=20,
         image_name="key:latest",
         image_config={"PortBindings": {"22/tcp": [{}]}},
     )
-    await Problem.create(
+    await PreEventProblem.create(
         name="Static_test",
         description="Chod de tujhe se na ho paye",
         author="Meetesh Saini",
-        points=300,
-        coins=20,
+        points=20,
         flag="asd",
+        url="lugvitc.org",
+    )
+    await PreEventProblem.create(
+        name="New Static Test",
+        description="AJJSBFISHDBFHSD",
+        author="Meetesh Saini",
+        points=21,
+        flag="asdf",
+        url="lugvitc.org",
     )
     await Problem.create(
         name="In-Plain-Sight",
@@ -80,7 +94,7 @@ async def init_db():
         name="Triple A battery", secret_hash=bcrypt.hash("chotiwali"), coins=20
     )
     await PreEventSolvedProblem.create(tag="23BCE1000", problem_id="1")
-    await PreEventSolvedProblem.create(tag="23BRS1000", problem_id="2")
+    await PreEventSolvedProblem.create(tag="23BRS1000", problem_id="1")
     # await PreEventSolvedProblem.create(
     #     tag="23BAI1000",
     #     problem_id="2"

--- a/src/pwncore/routes/admin.py
+++ b/src/pwncore/routes/admin.py
@@ -30,7 +30,9 @@ async def init_db():
         image_config={"PortBindings": {"22/tcp": [{}]}},
     )
     await Team.create(name="CID Squad", secret_hash=bcrypt.hash("veryverysecret"))
-    await Team.create(name="Triple A battery", secret_hash=bcrypt.hash("chotiwali"), coins=20)
+    await Team.create(
+        name="Triple A battery", secret_hash=bcrypt.hash("chotiwali"), coins=20
+    )
     await User.create(
         tag="23BRS1000",
         name="abc",

--- a/src/pwncore/routes/auth.py
+++ b/src/pwncore/routes/auth.py
@@ -21,26 +21,18 @@ metadata = {
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
-class SignupBody(BaseModel):
-    name: str
-    password: str
-    # members: list[str]
-
-
-class LoginBody(BaseModel):
+class AuthBody(BaseModel):
     name: str
     password: str
 
 
 @atomic()
 @router.post("/signup")
-async def signup_team(team: SignupBody, response: Response):
+async def signup_team(team: AuthBody, response: Response):
     try:
         if await Team.exists(name=team.name):
             response.status_code = 406
             return {"msg_code": config.msg_codes["team_exists"]}
-
-        # TODO: Add users details
 
         await Team.create(name=team.name, secret_hash=bcrypt.hash(team.password))
     except Exception:
@@ -50,7 +42,7 @@ async def signup_team(team: SignupBody, response: Response):
 
 
 @router.post("/login")
-async def team_login(team_data: LoginBody, response: Response):
+async def team_login(team_data: AuthBody, response: Response):
     # TODO: Simplified logic since we're not doing refresh tokens.
 
     team = await Team.get_or_none(name=team_data.name)

--- a/src/pwncore/routes/auth.py
+++ b/src/pwncore/routes/auth.py
@@ -54,8 +54,7 @@ async def team_login(team_data: AuthBody, response: Response):
         return {"msg_code": config.msg_codes["wrong_password"]}
 
     current_time = datetime.datetime.utcnow()
-    expiration_time = current_time + \
-        datetime.timedelta(hours=config.jwt_valid_duration)
+    expiration_time = current_time + datetime.timedelta(hours=config.jwt_valid_duration)
     token_payload = {"team_id": team.id, "exp": expiration_time}
     token = jwt.encode(token_payload, config.jwt_secret, algorithm="HS256")
 

--- a/src/pwncore/routes/auth.py
+++ b/src/pwncore/routes/auth.py
@@ -29,6 +29,7 @@ class AuthBody(BaseModel):
 @atomic()
 @router.post("/signup")
 async def signup_team(team: AuthBody, response: Response):
+    team.name = team.name.strip()
     try:
         if await Team.exists(name=team.name):
             response.status_code = 406

--- a/src/pwncore/routes/auth.py
+++ b/src/pwncore/routes/auth.py
@@ -62,7 +62,8 @@ async def team_login(team_data: LoginBody, response: Response):
         return {"msg_code": config.msg_codes["wrong_password"]}
 
     current_time = datetime.datetime.utcnow()
-    expiration_time = current_time + datetime.timedelta(hours=config.jwt_valid_duration)
+    expiration_time = current_time + \
+        datetime.timedelta(hours=config.jwt_valid_duration)
     token_payload = {"team_id": team.id, "exp": expiration_time}
     token = jwt.encode(token_payload, config.jwt_secret, algorithm="HS256")
 

--- a/src/pwncore/routes/ctf/__init__.py
+++ b/src/pwncore/routes/ctf/__init__.py
@@ -81,12 +81,14 @@ async def pre_event_flag_post(ctf_id: int, post_body: PreEventFlag, response: Re
         response.status_code = 404
         return {"msg_code": config.msg_codes["ctf_not_found"]}
 
-    if await PreEventSolvedProblem.exists(tag=post_body.tag, problem_id=ctf_id):
+    user_tag = post_body.tag.strip().casefold()
+
+    if await PreEventSolvedProblem.exists(tag=user_tag, problem_id=ctf_id):
         response.status_code = 401
         return {"msg_code": config.msg_codes["ctf_solved"]}
 
     if problem.flag == post_body.flag:
-        await PreEventSolvedProblem.create(tag=post_body.tag, problem_id=ctf_id)
+        await PreEventSolvedProblem.create(tag=user_tag, problem_id=ctf_id)
 
         return {"status": True}
     return {"status": False}

--- a/src/pwncore/routes/ctf/__init__.py
+++ b/src/pwncore/routes/ctf/__init__.py
@@ -39,10 +39,11 @@ async def ctf_list():
     return problems
 
 
+@atomic()
 @router.post("/{ctf_id}/flag")
 async def flag_post(ctf_id: int, flag: Flag, response: Response, jwt: RequireJwt):
     team_id = jwt["team_id"]
-    problem = await Problem.exists(id=ctf_id)
+    problem = await Problem.get_or_none(id=ctf_id)
     if not problem:
         response.status_code = 404
         return {"msg_code": config.msg_codes["ctf_not_found"]}
@@ -57,6 +58,11 @@ async def flag_post(ctf_id: int, flag: Flag, response: Response, jwt: RequireJwt
     )
     if check_solved:
         await SolvedProblem.create(team_id=team_id, problem_id=ctf_id)
+
+        team = await Team.get(id=team_id)
+        team.coins += problem.coins
+        await team.save()
+
         return {"status": True}
     return {"status": False}
 

--- a/src/pwncore/routes/ctf/__init__.py
+++ b/src/pwncore/routes/ctf/__init__.py
@@ -81,8 +81,6 @@ async def pre_event_flag_post(ctf_id: int, post_body: PreEventFlag, response: Re
         response.status_code = 404
         return {"msg_code": config.msg_codes["ctf_not_found"]}
 
-    print(problem)
-
     if await PreEventSolvedProblem.exists(tag=post_body.tag, problem_id=ctf_id):
         response.status_code = 401
         return {"msg_code": config.msg_codes["ctf_solved"]}

--- a/src/pwncore/routes/ctf/__init__.py
+++ b/src/pwncore/routes/ctf/__init__.py
@@ -12,7 +12,7 @@ from pwncore.models import (
     ViewedHint,
     Problem_Pydantic,
     Hint_Pydantic,
-    Team
+    Team,
 )
 from pwncore.config import config
 from pwncore.routes.ctf.start import router as start_router

--- a/src/pwncore/routes/ctf/pre_event.py
+++ b/src/pwncore/routes/ctf/pre_event.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Response
+from pydantic import BaseModel
+from tortoise.transactions import atomic
+
+from pwncore.models import (
+    PreEventProblem,
+    PreEventSolvedProblem,
+    BaseProblem_Pydantic,
+)
+from pwncore.config import config
+
+router = APIRouter(prefix="/pre", tags=["ctf"])
+
+
+class PreEventFlag(BaseModel):
+    tag: str
+    flag: str
+
+
+@router.get("/list")
+async def ctf_list():
+    problems = await BaseProblem_Pydantic.from_queryset(PreEventProblem.all())
+    return problems
+
+
+@atomic()
+@router.post("/{ctf_id}/flag")
+async def pre_event_flag_post(ctf_id: int, post_body: PreEventFlag, response: Response):
+    problem = await PreEventProblem.get_or_none(id=ctf_id)
+    if not problem:
+        response.status_code = 404
+        return {"msg_code": config.msg_codes["ctf_not_found"]}
+
+    user_tag = post_body.tag.strip().casefold()
+
+    if await PreEventSolvedProblem.exists(tag=user_tag, problem_id=ctf_id):
+        response.status_code = 401
+        return {"msg_code": config.msg_codes["ctf_solved"]}
+
+    if problem.flag == post_body.flag:
+        await PreEventSolvedProblem.create(tag=user_tag, problem_id=ctf_id)
+
+        return {"status": True}
+    return {"status": False}
+
+
+@router.get("/{ctf_id}")
+async def ctf_get(ctf_id: int, response: Response):
+    problem = await BaseProblem_Pydantic.from_queryset(
+        PreEventProblem.filter(id=ctf_id)
+    )
+    if not problem:
+        response.status_code = 404
+        return {"msg_code": config.msg_codes["ctf_not_found"]}
+    return problem

--- a/src/pwncore/routes/ctf/start.py
+++ b/src/pwncore/routes/ctf/start.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Response
 import uuid
 from tortoise.transactions import atomic
 
-from pwncore.models import Problem, Container, Ports, Team
+from pwncore.models import Problem, Container, Ports
 from pwncore.container import docker_client
 from pwncore.config import config
 from pwncore.routes.auth import RequireJwt
@@ -25,18 +25,6 @@ async def start_docker_container(ctf_id: int, response: Response, jwt: RequireJw
         }
     }
     """
-    if config.development:
-        await Problem.create(
-            name="Invisible-Incursion",
-            description="Chod de tujhe se na ho paye",
-            author="Meetesh Saini",
-            points=300,
-            image_name="key:latest",
-            image_config={"PortBindings": {"22/tcp": [{}]}},
-        )
-        await Team.create(
-            name="CID Squad" + uuid.uuid4().hex, secret_hash="veryverysecret"
-        )
 
     ctf = await Problem.get_or_none(id=ctf_id)
     if not ctf:

--- a/src/pwncore/routes/leaderboard.py
+++ b/src/pwncore/routes/leaderboard.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from fastapi import APIRouter
 from tortoise.functions import Sum
 
-from pwncore.models import SolvedProblem, Team
+from pwncore.models import Team
 
 # Metadata at the top for instant accessibility
 metadata = {"name": "leaderboard", "description": "Operations on the leaderboard"}
@@ -12,10 +12,10 @@ router = APIRouter(prefix="/leaderboard", tags=["leaderboard"])
 
 @router.get("")
 async def fetch_leaderboard():
-    points = (
+    leaderboard = dict(
         await Team.all()
         .annotate(team_points=Sum("solved_problem__problem__points"))
         .values_list("name", "team_points")
     )
     # points = sorted(points, key=lambda x: x[0], reverse=True)
-    return points
+    return leaderboard

--- a/src/pwncore/routes/leaderboard.py
+++ b/src/pwncore/routes/leaderboard.py
@@ -9,7 +9,7 @@ metadata = {"name": "leaderboard", "description": "Operations on the leaderboard
 router = APIRouter(prefix="/leaderboard", tags=["leaderboard"])
 
 
-@router.get("/fetch_leaderboard")
+@router.get("/")
 async def fetch_leaderboard():
     teams = await Team_Pydantic.from_queryset(Team.all())
     # points = await SolvedProblem.filter(team=2).values("problem__points")

--- a/src/pwncore/routes/leaderboard.py
+++ b/src/pwncore/routes/leaderboard.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from fastapi import APIRouter
 
-from pwncore.models import SolvedProblem, Team, Team_Pydantic
+from pwncore.models import SolvedProblem, Team
 
 # Metadata at the top for instant accessibility
 metadata = {"name": "leaderboard", "description": "Operations on the leaderboard"}
@@ -11,14 +11,17 @@ router = APIRouter(prefix="/leaderboard", tags=["leaderboard"])
 
 @router.get("/")
 async def fetch_leaderboard():
-    teams = await Team_Pydantic.from_queryset(Team.all())
+    teams = await Team.all()
     # points = await SolvedProblem.filter(team=2).values("problem__points")
     leaderboard = {}
     for team in teams:
         problems_solved_by_team = await SolvedProblem.filter(
             team__id=team.id
         ).values_list("problem__points", flat=True)
-        leaderboard[team.name] = sum(problems_solved_by_team)
+        # Tortoise's return type is List[Tuples] even after flat=True makes it List[]
+        # Hence ignore:
+        leaderboard[team.name] = sum(problems_solved_by_team)  # type: ignore[arg-type]
+
     # Uncomment to return sorted leaderboard
     # leaderboard = dict(sorted(leaderboard.items(), key=lambda x: x[0], reverse=True))
-    return leaderboard
+    return "asd"

--- a/src/pwncore/routes/leaderboard.py
+++ b/src/pwncore/routes/leaderboard.py
@@ -17,5 +17,5 @@ async def fetch_leaderboard():
         .annotate(team_points=Sum("solved_problem__problem__points"))
         .values_list("name", "team_points")
     )
-    points = sorted(points, key=lambda x: x[0], reverse=True)
+    # points = sorted(points, key=lambda x: x[0], reverse=True)
     return points

--- a/src/pwncore/routes/leaderboard.py
+++ b/src/pwncore/routes/leaderboard.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+from fastapi import APIRouter
+
+from pwncore.models import SolvedProblem, Team, Team_Pydantic
+
+# Metadata at the top for instant accessibility
+metadata = {"name": "leaderboard", "description": "Operations on the leaderboard"}
+
+router = APIRouter(prefix="/leaderboard", tags=["leaderboard"])
+
+
+@router.get("/fetch_leaderboard")
+async def fetch_leaderboard():
+    teams = await Team_Pydantic.from_queryset(Team.all())
+    # points = await SolvedProblem.filter(team=2).values("problem__points")
+    leaderboard = {}
+    for team in teams:
+        problems_solved_by_team = await SolvedProblem.filter(
+            team__id=team.id
+        ).values_list("problem__points", flat=True)
+        leaderboard[team.name] = sum(problems_solved_by_team)
+    # Uncomment to return sorted leaderboard
+    # leaderboard = dict(sorted(leaderboard.items(), key=lambda x: x[0], reverse=True))
+    return leaderboard

--- a/src/pwncore/routes/leaderboard.py
+++ b/src/pwncore/routes/leaderboard.py
@@ -9,10 +9,9 @@ metadata = {"name": "leaderboard", "description": "Operations on the leaderboard
 router = APIRouter(prefix="/leaderboard", tags=["leaderboard"])
 
 
-@router.get("/")
+@router.get("")
 async def fetch_leaderboard():
     teams = await Team.all()
-    # points = await SolvedProblem.filter(team=2).values("problem__points")
     leaderboard = {}
     for team in teams:
         problems_solved_by_team = await SolvedProblem.filter(
@@ -24,4 +23,4 @@ async def fetch_leaderboard():
 
     # Uncomment to return sorted leaderboard
     # leaderboard = dict(sorted(leaderboard.items(), key=lambda x: x[0], reverse=True))
-    return "asd"
+    return leaderboard

--- a/src/pwncore/routes/team.py
+++ b/src/pwncore/routes/team.py
@@ -57,7 +57,7 @@ async def add_member(user: UserAddBody, response: Response, jwt: RequireJwt):
             name=user.name,
             email=user.email,
             phone_num=user.phone_num,
-            team_id=team_id
+            team_id=team_id,
         )
     except Exception:
         response.status_code = 500
@@ -67,7 +67,7 @@ async def add_member(user: UserAddBody, response: Response, jwt: RequireJwt):
 
 @atomic()
 @router.post("/remove")
-async def add_member(user_info: UserRemoveBody, response: Response, jwt: RequireJwt):
+async def remove_member(user_info: UserRemoveBody, response: Response, jwt: RequireJwt):
     team_id = jwt["team_id"]
 
     user = await User.get_or_none(team_id=team_id, tag=user_info.tag)

--- a/src/pwncore/routes/team.py
+++ b/src/pwncore/routes/team.py
@@ -53,7 +53,7 @@ async def add_member(user: UserAddBody, response: Response, jwt: RequireJwt):
         await User.create(
             # Validation for user tag (reg. no. in our case)
             # needs to be done on frontend to not make the server event specific
-            tag=user.tag,
+            tag=user.tag.strip().casefold(),
             name=user.name,
             email=user.email,
             phone_num=user.phone_num,


### PR DESCRIPTION
This PR adds:
- Field coins to each team, defaulting to 0 on creation.
- Everytime a hint is requested, an amount is deducted from the team's coins. (amount can be set in `config.hint_penalty`)
- Team will not be allowed to view hints if they do not have the enough coins to do so.
- `/api/team/add` route creates a user and adds them to a given team. Returns 403 if user already exists in another team.
- `/api/team/remove` route removes a user from a team. Returns 403, if user is not a part of the selected team.