### PR TITLE
feat: /api/team/containers

### DIFF
--- a/src/pwncore/config.py
+++ b/src/pwncore/config.py
@@ -57,9 +57,9 @@ class Config:
 config = Config(
     development=True,
     db_url="sqlite://:memory:",
-    # docker_url=None,  # None for default system docker
+    docker_url=None,  # None for default system docker
     # Or set it to an arbitrary URL for testing without Docker
-    docker_url="http://google.com",
+    # docker_url="http://google.com",
     flag="C0D",
     max_containers_per_team=3,
     jwt_secret="mysecret",

--- a/src/pwncore/routes/team.py
+++ b/src/pwncore/routes/team.py
@@ -91,7 +91,7 @@ async def get_team_containers(response: Response, jwt: RequireJwt):
     for container in containers:
         result.append({
             "id": container.problem_id,
-            "ports": await container.ports.all().values_list("port", flat=True),
+            "ports": await container.ports.all().values_list("port", flat=True)
         })
 
     return result

--- a/src/pwncore/routes/team.py
+++ b/src/pwncore/routes/team.py
@@ -88,15 +88,9 @@ async def get_team_containers(response: Response, jwt: RequireJwt):
     containers = await Container.filter(team_id=jwt["team_id"]).prefetch_related(
         "ports", "problem"
     )
-    result = []
 
+    result = {}
     for container in containers:
-        result.append(
-            {
-                # mypy complains id doesnt exist in Problem
-                "id": container.problem.id,  # type: ignore[attr-defined]
-                "ports": await container.ports.all().values_list("port", flat=True),
-            }
-        )
+        result[container.problem.id] = await container.ports.all().values_list("port", flat=True)
 
     return result

--- a/src/pwncore/routes/team.py
+++ b/src/pwncore/routes/team.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from tortoise.transactions import atomic
 
 from pwncore.config import config
-from pwncore.models import Team, User, Team_Pydantic, User_Pydantic, Container
+from pwncore.models import Team, User, Team_Pydantic, User_Pydantic, Container, Ports
 from pwncore.routes.auth import RequireJwt
 
 # Metadata at the top for instant accessibility
@@ -85,7 +85,13 @@ async def remove_member(user_info: UserRemoveBody, response: Response, jwt: Requ
 
 @router.get("/containers")
 async def get_team_containers(response: Response, jwt: RequireJwt):
-    containers = await Container.filter(
-        team_id=jwt["team_id"]
-    ).values("problem_id")
-    return containers
+    containers = await Container.filter(team_id=jwt["team_id"]).prefetch_related("ports")
+    result = []
+
+    for container in containers:
+        result.append({
+            "id": container.problem_id,
+            "ports": await container.ports.all().values_list("port", flat=True),
+        })
+
+    return result

--- a/src/pwncore/routes/team.py
+++ b/src/pwncore/routes/team.py
@@ -91,6 +91,9 @@ async def get_team_containers(response: Response, jwt: RequireJwt):
 
     result = {}
     for container in containers:
-        result[container.problem.id] = await container.ports.all().values_list("port", flat=True)
+        # mypy complains id doesnt exist in Problem
+        result[container.problem.id] = await container.ports.all().values_list(  # type: ignore[attr-defined]
+            "port", flat=True
+        )
 
     return result

--- a/src/pwncore/routes/team.py
+++ b/src/pwncore/routes/team.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from tortoise.transactions import atomic
 
 from pwncore.config import config
-from pwncore.models import Team, User, Team_Pydantic, User_Pydantic
+from pwncore.models import Team, User, Team_Pydantic, User_Pydantic, Container
 from pwncore.routes.auth import RequireJwt
 
 # Metadata at the top for instant accessibility
@@ -81,3 +81,11 @@ async def remove_member(user_info: UserRemoveBody, response: Response, jwt: Requ
         response.status_code = 500
         return {"msg_code": config.msg_codes["db_error"]}
     return {"msg_code": config.msg_codes["user_removed"]}
+
+
+@router.get("/containers")
+async def get_team_containers(response: Response, jwt: RequireJwt):
+    containers = await Container.filter(
+        team_id=jwt["team_id"]
+    ).values("problem_id")
+    return containers


### PR DESCRIPTION
Returns a list of running containers of a given team in the format:
```py
{
    id: "3", // Problem ID
    ports: ["3454"]
}
```