### PR TITLE
add: metaTeam model

### DIFF
--- a/src/pwncore/models/__init__.py
+++ b/src/pwncore/models/__init__.py
@@ -13,7 +13,14 @@ from pwncore.models.ctf import (
     BaseProblem_Pydantic,
     Problem_Pydantic,
 )
-from pwncore.models.user import User, Team, Team_Pydantic, User_Pydantic
+from pwncore.models.user import (
+    User,
+    Team,
+    MetaTeam,
+    Team_Pydantic,
+    User_Pydantic,
+    MetaTeam_Pydantic,
+)
 from pwncore.models.pre_event import (
     PreEventProblem,
     PreEventSolvedProblem,
@@ -37,6 +44,8 @@ __all__ = (
     "User_Pydantic",
     "Team",
     "Team_Pydantic",
+    "MetaTeam",
+    "MetaTeam_Pydantic",
     "PreEventProblem_Pydantic",
     "Problem_Pydantic",
 )

--- a/src/pwncore/models/user.py
+++ b/src/pwncore/models/user.py
@@ -12,6 +12,8 @@ from pwncore.config import config
 __all__ = (
     "User",
     "Team",
+    "MetaTeam",
+    "MetaTeam_Pydantic",
     "User_Pydantic",
     "Team_Pydantic",
 )
@@ -54,9 +56,21 @@ class Team(Model):
     members: fields.ReverseRelation[User]
     containers: fields.ReverseRelation[Container]
 
+    meta_team: fields.ForeignKeyNullableRelation[MetaTeam] = fields.ForeignKeyField(
+        "models.MetaTeam", "teams", null=True, on_delete=fields.OnDelete.SET_NULL
+    )
+
     class PydanticMeta:
         exclude = ["secret_hash"]
 
 
+class MetaTeam(Model):
+    id = fields.IntField(pk = True)
+    name = fields.CharField(255, unique=True)
+
+    teams : fields.ReverseRelation[Team]
+
+
 Team_Pydantic = pydantic_model_creator(Team)
 User_Pydantic = pydantic_model_creator(User)
+MetaTeam_Pydantic = pydantic_model_creator(MetaTeam)


### PR DESCRIPTION
1. Added MetaTeam model with fields:

- id (Integer, Primary Key)
- name (String, Unique)

2. Added a reverse relation field _teams_ to establish a relationship with the _Team_ model.